### PR TITLE
Adding error logs to local machine

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,4 +47,5 @@ Vagrant.configure("2") do |config|
 
   config.vm.network :private_network, ip: findip()
   config.vm.synced_folder "./", "/var/www/#{$project}", :mount_options => ['dmode=777,fmode=777']
+  config.vm.synced_folder "./logs", "/var/log/apache2", :mount_options => ['dmode=777,fmode=777']
 end


### PR DESCRIPTION
Allows developers to browse errors using client applications (like Mac console).
