### PR TITLE
Windows Support, and HTTPS fix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,6 +49,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |box|
     box.memory = 1024
     box.cpus = 1
+    box.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
   end
 
   config.vm.provision "chef_solo" do |chef|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,5 @@
 require 'json'
+require 'rbconfig'
 
 # globals are bad mkay
 $project = File.basename(Dir.getwd)
@@ -42,27 +43,47 @@ def findip()
 end
 
 Vagrant.configure("2") do |config|
+
   config.vm.box = "opscode-ubuntu-14.04"
   config.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box"
+  config.vm.synced_folder "./", "/var/www/#{$project}", :mount_options => ['dmode=777,fmode=777']
+
   config.omnibus.chef_version = '11.16.0'
 
-  config.vm.provider "virtualbox" do |box|
+  config.vm.provider "virtualbox" do |box, override|
     box.memory = 1024
     box.cpus = 1
-    #this requires using shared folders, resolving
-    #box.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{$project}", "1"]
+	
+	if RbConfig::CONFIG['host_os'] =~ /mswin|win|mingw/
+	  # Allows long filenames in Windows
+	  # See: https://github.com/mitchellh/vagrant/issues/1953
+      box.customize ["sharedfolder", "add", :id, "--name", "project", "--hostpath", (("//?/" + File.dirname(__FILE__)).gsub("/","\\"))]
+      
+      # Allow symlinks (Run `vagrant up` from a CMD Prompt with Admin Privs)
+      box.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/project", "1"]
+      
+	  # Dissable the "default" Synced Folder mount (via Vagrant) in favor of VBox
+	  override.vm.synced_folder "./", "/var/www/#{$project}", disabled: true
+      
+	  # This is the default way the folder is typically created
+	  override.vm.provision :shell, inline: "mkdir /var/www/#{$project} -p"
+	  override.vm.provision :shell, inline: "mount -t vboxsf -o uid=`id -u vagrant`,gid=`getent group vagrant | cut -d: -f3` project /var/www/#{$project}", run: "always"
+	end
+	
+	# Ensures this only executes on VirtualBox
+	override.vm.provision "chef_solo" do |chef|
+	  json = JSON.parse( IO.read("attributes/default.json") )
+	  json.store('project', $project)
+	  
+	  chef.custom_config_path = "./vendor/vagrantfile/Vagrantfile.chef"
+	  chef.environment        = "development"
+	  chef.cookbooks_path     = "cookbooks/"
+	  chef.environments_path  = "environments/"
+	  chef.json               = json
+	end
+	
+	config.vm.network :private_network, ip: findip()
+	
   end
-
-  config.vm.provision :shell, :inline => 'apt-get update'
-
-  config.vm.provision "chef_solo" do |chef|
-    chef.custom_config_path = "./vendor/vagrantfile/Vagrantfile.chef"
-    chef.environment        = "development"
-    chef.cookbooks_path     = "cookbooks/"
-    chef.environments_path  = "environments/"
-    chef.json               = JSON.parse( IO.read("attributes/default.json") )
-  end
-
-  config.vm.network :private_network, ip: findip()
-  config.vm.synced_folder "./", "/var/www/#{$project}", :mount_options => ['dmode=777,fmode=777']
+  
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,10 +55,11 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, :inline => 'apt-get update'
 
   config.vm.provision "chef_solo" do |chef|
-    chef.environment       = "development"
-    chef.cookbooks_path    = "cookbooks/"
-    chef.environments_path = "environments/"
-    chef.json              = JSON.parse( IO.read("attributes/default.json") )
+    chef.custom_config_path = "./vendor/vagrantfile/Vagrantfile.chef"
+    chef.environment        = "development"
+    chef.cookbooks_path     = "cookbooks/"
+    chef.environments_path  = "environments/"
+    chef.json               = JSON.parse( IO.read("attributes/default.json") )
   end
 
   config.vm.network :private_network, ip: findip()

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,35 +53,35 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |box, override|
     box.memory = 1024
     box.cpus = 1
-	
-	if RbConfig::CONFIG['host_os'] =~ /mswin|win|mingw/
-	  # Allows long filenames in Windows
-	  # See: https://github.com/mitchellh/vagrant/issues/1953
+    
+    if RbConfig::CONFIG['host_os'] =~ /mswin|win|mingw/
+      # Allows long filenames in Windows
+      # See: https://github.com/mitchellh/vagrant/issues/1953
       box.customize ["sharedfolder", "add", :id, "--name", "project", "--hostpath", (("//?/" + File.dirname(__FILE__)).gsub("/","\\"))]
       
       # Allow symlinks (Run `vagrant up` from a CMD Prompt with Admin Privs)
       box.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/project", "1"]
       
-	  # Dissable the "default" Synced Folder mount (via Vagrant) in favor of VBox
-	  override.vm.synced_folder "./", "/var/www/#{$project}", disabled: true
+      # Dissable the "default" Synced Folder mount (via Vagrant) in favor of VBox
+      override.vm.synced_folder "./", "/var/www/#{$project}", disabled: true
       
-	  # This is the default way the folder is typically created
-	  override.vm.provision :shell, inline: "mkdir /var/www/#{$project} -p"
-	  override.vm.provision :shell, inline: "mount -t vboxsf -o uid=`id -u vagrant`,gid=`getent group vagrant | cut -d: -f3` project /var/www/#{$project}", run: "always"
-	end
-	
-	# Ensures this only executes on VirtualBox
-	override.vm.provision "chef_solo" do |chef|
-	  json = JSON.parse( IO.read("attributes/default.json") )
-	  json.store('project', $project)
-	  
-	  chef.custom_config_path = "./vendor/vagrantfile/Vagrantfile.chef"
-	  chef.environment        = "development"
-	  chef.cookbooks_path     = "cookbooks/"
-	  chef.environments_path  = "environments/"
-	  chef.json               = json
-	end
-	
+      # This is the default way the folder is typically created
+      override.vm.provision :shell, inline: "mkdir /var/www/#{$project} -p"
+      override.vm.provision :shell, inline: "mount -t vboxsf -o uid=`id -u vagrant`,gid=`getent group vagrant | cut -d: -f3` project /var/www/#{$project}", run: "always"
+    end
+    
+    # Ensures this only executes on VirtualBox
+    override.vm.provision "chef_solo" do |chef|
+      json = JSON.parse( IO.read("attributes/default.json") )
+      json.store('project', $project)
+      
+      chef.custom_config_path = "./vendor/vagrantfile/Vagrantfile.chef"
+      chef.environment        = "development"
+      chef.cookbooks_path     = "cookbooks/"
+      chef.environments_path  = "environments/"
+      chef.json               = json
+    end
+    
   end
   
   config.vm.network :private_network, ip: findip()

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,7 +49,8 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |box|
     box.memory = 1024
     box.cpus = 1
-    box.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
+    #this requires using shared folders, resolving
+    #box.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{$project}", "1"]
   end
 
   config.vm.provision :shell, :inline => 'apt-get update'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,8 +82,8 @@ Vagrant.configure("2") do |config|
 	  chef.json               = json
 	end
 	
-	config.vm.network :private_network, ip: findip()
-	
   end
+  
+  config.vm.network :private_network, ip: findip()
   
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,6 +52,8 @@ Vagrant.configure("2") do |config|
     box.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
   end
 
+  config.vm.provision :shell, :inline => 'apt-get update'
+
   config.vm.provision "chef_solo" do |chef|
     chef.environment       = "development"
     chef.cookbooks_path    = "cookbooks/"

--- a/Vagrantfile.chef
+++ b/Vagrantfile.chef
@@ -1,0 +1,1 @@
+Chef::Config.ssl_verify_mode = :verify_peer


### PR DESCRIPTION
1. Adds support for Long Path names and Symlinks for Windows VirtualBox.
2. Ensures that Chef Solo only runs on VirtualBox (only supported).
3. Resolves an HTTPS error when forking Chef:

``````
==> default: Running chef-solo...
==> default: stdin: is not a tty
==> default: [2015-04-27T18:47:43+00:00] INFO: Forking chef instance to converge...
==> default: [2015-04-27T18:47:43+00:00] WARN:
==> default: * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
==> default: SSL validation of HTTPS requests is disabled. HTTPS connections are still
==> default: encrypted, but chef is not able to detect forged replies or man in the middle
==> default: attacks.
==> default:
==> default: To fix this issue add an entry like this to your configuration file:
==> default:
==> default: ```
==> default:   # Verify all HTTPS connections (recommended)
==> default:   ssl_verify_mode :verify_peer
==> default:
==> default:   # OR, Verify only connections to chef-server
==> default:   verify_api_cert true
==> default: ```
==> default:
==> default: To check your SSL configuration, or troubleshoot errors, you can use the
==> default: `knife ssl check` command like so:
==> default:
==> default: ```
==> default:   knife ssl check -c /tmp/vagrant-chef/solo.rb
==> default: ```
==> default:
==> default: * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
==> default: [2015-04-27T18:47:43+00:00] INFO: *** Chef 11.16.0 ***
==> default: [2015-04-27T18:47:43+00:00] INFO: Chef-client pid: 1467
==> default: [2015-04-27T18:47:50+00:00] INFO: Setting the run_list to ["recipe[startupgenome]"] from CLI options
``````

Sorry that there are a number of commits for what amounts to a small change, as a first foray into Vagrant, it was quite the learning experience.
